### PR TITLE
Added missing formats for FAQ, as per issue #29

### DIFF
--- a/docs/md/faq.md
+++ b/docs/md/faq.md
@@ -8,7 +8,7 @@ If you experience any issues with Lychee and wish to report it, make sure to spe
 
 ### Which file formats are supported?
 
-Lychee supports major image formats, and since version 3.2.1 some video formats as well. Specifically, `*.jpg`, `*.jpeg`, `*.png`, `*.gif`, `*.ogv`, `*.mp4`, `*.webm`, and `*.mov` are accepted.
+Lychee supports major image formats, and since version 3.2.1 some video formats as well. Specifically, `*.jpg`, `*.jpeg`, `*.png`, `*.gif`, `*.ogv`, `*.mp4`, `*.mpg`, `*.webm`, `*.webp`, `*.mov`, `*.m4v`, `*.avi` and `*.wmv` are accepted.
 
 If you're uploading video files, make sure to increase your upload limits in `php.ini`.  See the [Installation](installation.html) section for more information.
 


### PR DESCRIPTION
Again, the title is pretty much self-explanatory here!
I hope this fixes the issue #29, as all allowed file extensions are listed now, in the same order as in [source code](https://github.com/LycheeOrg/Lychee/blob/3d46ab0d0af8f725f78b158a1c238ed359ffc527/app/Actions/Photo/Extensions/Constants.php#L37).