### PR TITLE
Added mention of the lychee_session cookie in faq and in api documentation

### DIFF
--- a/docs/md/api.md
+++ b/docs/md/api.md
@@ -20,7 +20,7 @@ See:
 
 - **POST** request
 - Returns `true` if login was successful, `false` otherwise.
-- Returns a laravel session cookie (`lychee_session`) needed for logged-in operations.
+- Returns a laravel session cookie (`lychee_session`) which must be passed to subsequent requests that require an authenticated user.
 ```
 $request->validate([
     'username' => 'required',

--- a/docs/md/faq.md
+++ b/docs/md/faq.md
@@ -32,8 +32,10 @@ Either press `n` (as **N**ew) or use the add menu.
 
 ### What headers need to be used to authenticate with the custom `api_key` in the settings?
 
-In order to bypass the CSRF protection, you can set up the `api_key` setting to a secret value and send that value over in the `Authorization` header.
-Note that you will still need to authenticate yourself to the server (using [Session::login](https://lycheeorg.github.io/docs/api.html#apisessionlogin) and the returned `lychee_session` cookie), this disable only the CSRF protection.
+In order to bypass the CSRF protection, you can set up the `api_key` setting to a secret value and send that value over in the `Authorization` header.  
+Note that `api_key` only disables the CSRF protection, you still need to authenticate to the server.
+
+In order to authenticate, use [Session::login](https://lycheeorg.github.io/docs/api.html#apisessionlogin) and pass the returned `lychee_session` cookie to all subsequent requests.
 
 The related code is available [here](https://github.com/LycheeOrg/Lychee/blob/master/app/Http/Middleware/VerifyCsrfToken.php#L55)
 


### PR DESCRIPTION
This PR fixes issue https://github.com/LycheeOrg/Lychee/issues/1114, by adding a mention of the `lychee_session` cookie in faq and api sections of the documentation.
I can remove any of the mentions, if you only want one mention in faq or in api. As I hesitated, I've added both.
Feedback is welcome, of course :clap: 

edit: rebased my branch on older master, as merging this one would merge my other one too, which is unwanted