### PR TITLE
Fix: github URL on footer

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -85,7 +85,7 @@ structure += [['Digging Deeper',
 
 def gen_github_link(page):
     html = '<blockquote><p>{tip} Caught a mistake or want to contribute to the documentation?&nbsp;'
-    html += '<a href="https://github.com/LycheeOrg/LycheeOrg.github.io/tree/master/docs/md/' + page + '.md">Edit this page on Github!</a></p></blockquote>'
+    html += '<a href="https://github.com/LycheeOrg/LycheeOrg.github.io/tree/master/docs/' + page + '.md">Edit this page on Github!</a></p></blockquote>'
     return html
 
 def gen_sidebar(page):


### PR DESCRIPTION
All github links in the footer are currently broken due to an old URL format. Removing 'md/' at the end correctly resolves the URL to the repo. Example: at 'https://lycheeorg.github.io/docs/installation.html', the current footer goes to 'https://github.com/LycheeOrg/LycheeOrg.github.io/tree/master/docs/md/installation.md' while this change should resolve to 'https://github.com/LycheeOrg/LycheeOrg.github.io/blob/master/docs/installation.md'