### PR TITLE
Synchronize/update the list of PHP extensions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,24 +10,28 @@ The Lychee gallery has a few system requirements. You will need to make sure you
 	- PostgreSQL _(version > 9.2)_
 	- Lychee's inbuilt SQLite3 support
 - PHP >= 8.0 with these PHP extensions:
-	- BCMath
-	- Ctype
-	- Exif
-	- Fileinfo
-	- GD
-	- Imagick (optional &mdash; to generate better thumbnails)
-	- JSON
-   	- Mbstring
-   	- OpenSSL
-   	- PDO
-   	- Tokenizer
-   	- XML
-   	- ZIP
-- These PHP extensions are necessary if you are running a FreeBSD system:
-	- Simplexml
-	- Dom
-	- Session
-	- Zlib
+	- bcmath
+	- ctype
+	- dom
+	- exif
+	- fileinfo
+	- filter
+	- gd
+	- imagick (optional &mdash; to generate better thumbnails)
+	- json
+	- libxml
+	- mbstring
+	- openssl
+	- pcre
+	- PDO
+	- Phar
+	- SimpleXML
+	- tokenizer
+	- xml
+	- xmlwriter
+- These PHP extensions may be necessary if you are running a FreeBSD system:
+	- session
+	- zlib
 - You will also need one of these PHP extensions:
 	- SQLite3 for SQLite3 databases
 	- MySQLi (or PDO_MySQL) for MySQL or MariaDB databases


### PR DESCRIPTION
Documentation part of https://github.com/LycheeOrg/Lychee/pull/1375. While I was there, I fixed the capitalization to actually match what `php -m` prints.

The part about FreeBSD seems suspicious to me but I decided to keep it.