### PR TITLE
Tweak contributors. Partially reverts #77

### DIFF
--- a/template/footer.tpl
+++ b/template/footer.tpl
@@ -3,7 +3,7 @@
 <div class="footer__column">
   <div class="align align--left">
 
-    <p>Made by <a class="footer__link" href="https://github.com/LycheeOrg">LycheeOrg</a></p>
+    <p>Maintained by <a class="footer__link" href="https://github.com/LycheeOrg">LycheeOrg</a></p>
 
   </div>
 </div>

--- a/template/support.tpl
+++ b/template/support.tpl
@@ -60,6 +60,14 @@
 	<div class="contributors_list">
 
 		<p class="contributors">
+			<img class="avatar" src="https://avatars.githubusercontent.com/u/499088?v=4">
+			<span>
+				electerious (Tobias Reich) - Creator<br>
+				<a href="https://github.com/electerious">GitHub</a>
+			</span>
+		</p>
+
+		<p class="contributors">
 			<img class="avatar" src="https://avatars.githubusercontent.com/u/1869257?s=400&v=4">
 			<span>
 				tmp-hallenser<br>
@@ -113,14 +121,6 @@
 			<span>
 				bennetscience (Brian)<br>
 				<a href="https://github.com/bennetscience">GitHub</a>
-			</span>
-		</p>
-
-		<p class="contributors">
-			<img class="avatar" src="https://avatars.githubusercontent.com/u/499088?v=4">
-			<span>
-				electerious (Tobias Reich)<br>
-				<a href="https://github.com/electerious">GitHub</a>
 			</span>
 		</p>
 


### PR DESCRIPTION
Put electerious back into the footer, with clearer distinction of roles. Also move to the top of past contributors, as he was the first.