### PR TITLE
Align required PHP version with the one in Lychee/README.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ The Lychee gallery has a few system requirements. You will need to make sure you
 	- MySQL _(version > 5.7.8)_ / MariaDB _(version > 10.2)_
 	- PostgreSQL _(version > 9.2)_
 	- Lychee's inbuilt SQLite3 support
-- PHP >= 8.0 with these PHP extensions:
+- PHP >= 8.1 with these PHP extensions:
 	- bcmath
 	- ctype
 	- dom


### PR DESCRIPTION
The minimum PHP version doesn't match the one from Lychee/README.md, this PR fix it.

![image](https://github.com/LycheeOrg/LycheeOrg.github.io/assets/21085847/314788ca-1254-471f-9541-426c2517c018)
