### PR TITLE
Add instructions for hosting Lychee in a subpath with Apache

### DIFF
--- a/docs/advanced-setups.md
+++ b/docs/advanced-setups.md
@@ -290,4 +290,57 @@ To avoid latency when clicking Diagnostics, my suggestion is to disable BasicPer
 ### Limitations to be considered
 As explained before, recursive tasks are penalised in Object Storage, so if you have an existing bucket and the container runs for the first time, it will take long time to review and set the permissions in your mount. Depending on the number of photos, it can take several hours.
 
+## Hosting Lychee in a subpath with Apache
+
+To serve Lychee in a subpath, e.g. `https://my.url/photos/`, we can use Apaches's [Alias](https://httpd.apache.org/docs/2.4/mod/mod_alias.html#alias)-directive.
+
+In this example we assume the web root to be located at `/var/www/html`, the web user and group to be `www-data`, and install [from the master branch](installation.html#from-the-master-branch).
+
+Before getting started, make sure your system qualifies the [Server Requirements](installation.html#server-requirements). 
+
+### Setup Lychee
+
+Clone the repository to outside the web root, e.g. `/var/www/`:
+``` bash
+sudo git clone https://www.github.com/LycheeOrg/Lychee /var/www/
+```
+
+Set the file ownership and permissions:
+``` bash
+sudo chown -R www-data:www-data /var/www/Lychee
+sudo chmod -R 2775 /var/www/Lychee
+```
+
+Install composer in `/var/www/Lychee` as instructed in [here](https://getcomposer.org/download/). Then, from `/var/www/Lychee`, install the project dependencies:
+``` bash
+sudo -u www-data php composer.phar install --no-dev
+```
+
+### Setup Apache
+
+Link `https://my.url/photos/` to `/var/www/Lychee/public` by adding the following to your Apache configuration for Aliases. In Apache 2.4 running on Debian, the correct configuration file is `/etc/apache2/mods-available/alias.conf`.
+``` php
+Alias /photos /var/www/Lychee/public
+
+<Directory /var/www/Lychee/public>
+   Options FollowSymLinks
+   AllowOverride All
+   Require all granted
+</Directory>
+```
+
+Finally, restart Apache:
+```
+sudo service apache2 restart
+```
+
+### Configure Lychee
+
+At this point, you should be able to go to `https://my.url/photos/` and run the web installer. During the installation procedure, on top of adding the database credentials to match your setup, set your `APP_URL` to the served subdirectory:
+```
+APP_URL=https://my.url/photos/
+```
+
+Done!
+
 </div>

--- a/docs/advanced-setups.md
+++ b/docs/advanced-setups.md
@@ -301,25 +301,29 @@ Before getting started, make sure your system qualifies the [Server Requirements
 ### Setup Lychee
 
 Clone the repository to outside the web root, e.g. `/var/www/`:
-``` bash
+
+```bash
 sudo git clone https://www.github.com/LycheeOrg/Lychee /var/www/
 ```
 
 Set the file ownership and permissions:
-``` bash
+
+```bash
 sudo chown -R www-data:www-data /var/www/Lychee
 sudo chmod -R 2775 /var/www/Lychee
 ```
 
 Install composer in `/var/www/Lychee` as instructed in [here](https://getcomposer.org/download/). Then, from `/var/www/Lychee`, install the project dependencies:
-``` bash
+
+```bash
 sudo -u www-data php composer.phar install --no-dev
 ```
 
 ### Setup Apache
 
 Link `https://my.url/photos/` to `/var/www/Lychee/public` by adding the following to your Apache configuration for Aliases. In Apache 2.4 running on Debian, the correct configuration file is `/etc/apache2/mods-available/alias.conf`.
-``` php
+
+```apacheconf
 Alias /photos /var/www/Lychee/public
 
 <Directory /var/www/Lychee/public>
@@ -330,14 +334,16 @@ Alias /photos /var/www/Lychee/public
 ```
 
 Finally, restart Apache:
-```
+
+```bash
 sudo service apache2 restart
 ```
 
 ### Configure Lychee
 
 At this point, you should be able to go to `https://my.url/photos/` and run the web installer. During the installation procedure, on top of adding the database credentials to match your setup, set your `APP_URL` to the served subdirectory:
-```
+
+```bash
 APP_URL=https://my.url/photos/
 ```
 

--- a/docs/faq_installation.md
+++ b/docs/faq_installation.md
@@ -61,8 +61,7 @@ location @lychee {
 
 ### Can I host Lychee with a subpath with Apache? Like `https://example.dev/lychee/`
 
-Yes, just create a Symbolic Link and allow your apache configuration to follow them.
-At website.com root `ln -s Lychee/public pics` and you will get exactly what you want: `website.com/pics`
+Yes, the process is described [here](advanced-setups.html#hosting-lychee-in-a-subpath-with-apache).
 
 ### Do we really need writable `app/`?
 


### PR DESCRIPTION
Adds instructions for hosting Lychee in a subpath with Apache, as discussed [here](https://github.com/LycheeOrg/Lychee/issues/1993).

Couple of things to note:

While in the original thread I had adjusted the environment variables `LYCHEE_UPLOADS[_URL]`, `LYCHEE_DIST[_URL]` and `LYCHEE_SYM[_URL]` to match the setup, it seems like Lychee runs fine even without those variables explicitly set. Does that make sense? Because of this, I didn't include that part into the instructions.

Second, while the updated instructions work fine when rendered as a Markdown file, in my system, the compiled HTML somehow breaks _before_ the newly added section. I don't see anything weird in the syntax that would cause the file to break, but I also don't understand how the markdown gets converted to HTML. This should be checked before merging.