### PR TITLE
Corrected link to FAQ with CSS examples

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -78,7 +78,7 @@ Note that enabling the maps adds a viewing-time dependency of your gallery on an
 
 ## CSS Personalization
 
-Much of the appearance of the Lychee web interface is determined by the CSS.  The bottom of the basic settings screen features a text input field where custom CSS can be entered to tweak the Lychee user interface.  Effective use of this feature requires the knowledge of CSS and the internals of the [Lychee front end](frontend.html) which go beyond the scope of this document, but check the [FAQ](faq.html) for a few examples.
+Much of the appearance of the Lychee web interface is determined by the CSS.  The bottom of the basic settings screen features a text input field where custom CSS can be entered to tweak the Lychee user interface.  Effective use of this feature requires the knowledge of CSS and the internals of the [Lychee front end](frontend.html) which go beyond the scope of this document, but check the [FAQ](faq_general.html) for a few examples.
 
 Unlike the rest of the config, this field is stored in the text file `public/dist/user.css` and can be modified directly there using your favorite editor.
 


### PR DESCRIPTION
Seems faq.html is no longer available, probably because it was split into multiple faq files. 
Corrected the link so it doesn't return 404 anymore.