### PR TITLE
Fix http instead of https...

### DIFF
--- a/src/pages/support.astro
+++ b/src/pages/support.astro
@@ -282,8 +282,8 @@ const metadata = {
         <h2 class="text-3xl md:text-4xl font-bold leading-tighter tracking-tighter font-heading" set:html={'Translation efforts'} />
         <div class="mt-2 md:mt-3 mx-auto text-xl text-gray-500 dark:text-slate-400 font-medium" set:html={'It only takes a little bit of your time, but it greatly helps us.'} />
       </div>
-      <a href="http://weblate.lycheeorg.dev/engage/lycheeorg/" class="flex justify-center">
-        <img src="http://weblate.lycheeorg.dev/widget/lycheeorg/multi-auto.svg" class="w-full" alt="Translation status" />
+      <a href="https://weblate.lycheeorg.dev/engage/lycheeorg/" class="flex justify-center">
+        <img src="https://weblate.lycheeorg.dev/widget/lycheeorg/multi-auto.svg" class="w-full" alt="Translation status" />
       </a>
       <div class="flex w-full sm:w-auto my-4 justify-center">
         <Button


### PR DESCRIPTION
This pull request includes a minor update to the `src/pages/support.astro` file. The change updates the URLs for the translation status widget to use secure `https` links instead of `http`.

* **URL Update for Translation Widget**:
  - Updated the `href` and `src` attributes in the translation status widget to use `https` instead of `http` for secure connections. (`[src/pages/support.astroL285-R286](diffhunk://#diff-66456f0d1b862e03ec225b951976dac9c4cc837fd9e46b145aacc27dcc675d90L285-R286)`)