### PR TITLE
version 6.6.5

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -30,6 +30,20 @@
 
 ## Version 6
 
+### v6.6.5
+
+Released on May 27, 2025
+
+#### Temporary and Secure link fixes
+
+This is a small release that fixes the temporary links and AES-secured links which were broken on docker.
+We also split the functionality: you can either use the secure link or the temporary link, or both at the same time.
+
+PS: AES-secured links are only available in the Supporter Edition.
+
+* `fixes` #3373 : Fix temporary URL on docker setup by @ildyria.
+  > This fixes the temporary links which were broken on docker.
+
 ### v6.6.4
 
 Releaed on May 25, 2025
@@ -37,6 +51,7 @@ Releaed on May 25, 2025
 #### Fixes and improved visuals.
 
 This small release fixes an indexing bug in the timeline view mode and adds a few visual improvements, namely:
+
 - The ability to change the size of the previous/next buttons in the photo view.
 - An annimation when switching images in the photo view.
 - A proper login page instead of a modal.

--- a/src/components/widgets/Announcement.astro
+++ b/src/components/widgets/Announcement.astro
@@ -10,8 +10,8 @@
     >NEW</span
   >
   <a
-    href="https://github.com/LycheeOrg/Lychee/releases/tag/v6.6.4"
-    class="text-slate-200 hover:underline dark:text-slate-200 font-medium">Lychee 6.6.4 is now available! »</a
+    href="https://github.com/LycheeOrg/Lychee/releases/tag/v6.6.5"
+    class="text-slate-200 hover:underline dark:text-slate-200 font-medium">Lychee 6.6.5 is now available! »</a
   >
   <a
     target="_blank"


### PR DESCRIPTION
This pull request updates the release notes in `docs/releases.md` to document the changes introduced in version 6.6.5. It includes details about fixes to temporary and AES-secured links, particularly for Docker setups, and clarifies functionality for using secure and temporary links.

Key changes:

### Documentation updates:
* Added a new section for version `v6.6.5`, released on May 27, 2025, which highlights:

  - Fixes for temporary links on Docker setups.
  - The ability to use secure links, temporary links, or both simultaneously, with AES-secured links being exclusive to the Supporter Edition.