### PR TITLE
Prepare version 7.6.4

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -42,7 +42,7 @@ Released on June 26th, 2026
 #### Fixes a high vulnerability on temporary images link
 
 This one is quite stupid and came from the assumption that `Storage::disk('local')->path($path)` would always apply the normalization and return the canonical path.
-We have set mitigatios against path traversal, but the normalization was not applied, allowing for a path traversal attack on the temporary image link.
+We have set mitigations against path traversal, but the normalization was not applied, allowing for a path traversal attack on the temporary image link.
 
 So the bad news: If you have enabled **temporary links and** have **extra users (non-guest)** you will want to update ASAP and rotate your secrets, I'm so sorry.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -35,6 +35,27 @@
 
 ## What's Changed
 
+### v7.6.4
+
+Released on June 26th, 2026
+
+#### Fixes a high vulnerability on temporary images link
+
+This one is quite stupid and came from the assumption that `Storage::disk('local')->path($path)` would always apply the normalization and return the canonical path.
+We have set mitigatios against path traversal, but the normalization was not applied, allowing for a path traversal attack on the temporary image link.
+
+So the bad news: If you have enabled **temporary links and** have **extra users (non-guest)** you will want to update ASAP and rotate your secrets, I'm so sorry.
+
+Now the good news, you are safe if any of the following applies to your installation: 
+- you are running docker and did not mount .env (in other words using environment variables instead of files)
+- you did not have the temporary link functionality enabled
+- you had the temporary link functionality enabled but also have it enabled for normal users (non-guest).
+- you are using encrypted paths (SE users only)
+
+If you have been impacted, we recommend you to rotate your `APP_KEY` and other secrets in your .env file.
+
+* `fix` #4465 : Fix path traversal on temporary image link by @ildyria.
+
 ### v7.6.3
 
 Released on June 24th, 2026

--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -8,7 +8,8 @@ const metadata = {
 
 // Release data extracted from releases.md
 export const releases = [
-  { version: 'v7.6.3', date: 'Jun 24, 2026', title: 'Hotfix', type: 'security', highlights: ['Fixes major vulnerability', 'minor fixes'] },
+  { version: 'v7.6.4', date: 'Jun 26, 2026', title: 'Hotfix', type: 'security', highlights: ['Fixes a path traversal vulnerability (8.9)'] },
+  { version: 'v7.6.3', date: 'Jun 24, 2026', title: 'Hotfix', type: 'security', highlights: ['Fixes a major vulnerability', 'minor fixes'] },
   { version: 'v7.6.2', date: 'Jun 22, 2026', title: 'Hotfix', type: 'bugfix', highlights: ['Revert change to avoid breaking docker installs.'] },
   { version: 'v7.6.1', date: 'Jun 22, 2026', title: 'Hotfix', type: 'security', highlights: ['🌟 License key auto-rotations', 'Fix brute force attack on unlock'] },
   { version: 'v7.6.0', date: 'Jun 17, 2026', title: 'Moderation, Custom print sizes and more', type: 'major', highlights: ['Chunked download', 'Moderation features', 'folder upload', '🌟 Custom print sizes (SE)', '🌟 White-label (SE)'] },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new release note entry for v7.6.4 highlighting a security issue with temporary image links.
  * Included guidance on when installations are considered safe and advised rotating secrets if impacted.
  * Updated recent release notes wording for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->