### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/src/content/docs/docs/administration/advanced-setups.md
+++ b/src/content/docs/docs/administration/advanced-setups.md
@@ -112,6 +112,14 @@ Feel free to open an [Issue](https://github.com/breuerfelix/lychee-helmchart/iss
 
 [Marius Bogdan Lixandru](https://mariushosting.com/author/marius/) made a great post of how to set up your Lychee installation on your Synology NAS with Portainer. Read at it [here](https://mariushosting.com/how-to-install-lychee-on-your-synology-nas/).
 
+### With Zenith (Paid)
+
+Zenith provides one-click managed hosting for open-source apps, so you can bring up a fully managed Lychee instance in minutes without any server setup.
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/lychee)
+
+You can find their Lychee offering [here](https://zenith.hosting/host/lychee).
+
 ## Implementing Object Storage 
 
 An S3-compatible object storage solution is designed to store, manage, and access unstructured data in the cloud. 


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Lychee to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the "Other means of distributions" section (links to https://zenith.hosting/host/lychee).

thanks @ildyria for pointing me to the right file. we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “With Zenith (Paid)” section to the distribution options page.
  * Included a short overview of managed hosting, plus links to deploy with Zenith and learn more about its Lychee offering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->